### PR TITLE
Remove active flag on passwords and just use date_created to determin…

### DIFF
--- a/cas/src/main/java/org/apereo/cas/infusionsoft/dao/UserPasswordDAO.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/dao/UserPasswordDAO.java
@@ -6,14 +6,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
-import java.util.List;
-
 public interface UserPasswordDAO extends PagingAndSortingRepository<UserPassword, Long> {
-    List<UserPassword> findByUserAndPasswordEncodedOrderByActiveDescDateCreatedDesc(User user, String encodedPassword);
+    UserPassword findFirstByUserAndPasswordEncodedOrderByDateCreatedDesc(User user, String encodedPassword);
 
-    List<UserPassword> findByUserAndPasswordEncodedMD5OrderByActiveDescDateCreatedDesc(User user, String md5EncodedPassword);
+    UserPassword findFirstByUserAndPasswordEncodedMD5OrderByDateCreatedDesc(User user, String encodedPassword);
 
-    UserPassword findByUserAndActiveTrue(User user);
+    UserPassword findFirstByUserOrderByDateCreatedDesc(User user);
 
     Page<UserPassword> findByUser(User user, Pageable pageable);
 }

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/domain/UserPassword.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/domain/UserPassword.java
@@ -13,7 +13,6 @@ public class UserPassword implements Serializable {
     private String passwordEncoded;
     private String passwordEncodedMD5;
     private Date dateCreated;
-    private boolean active = false;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -62,12 +61,4 @@ public class UserPassword implements Serializable {
         this.dateCreated = new Date(dateCreated.getTime());
     }
 
-    @Column(name = "active")
-    public boolean isActive() {
-        return active;
-    }
-
-    public void setActive(boolean active) {
-        this.active = active;
-    }
 }

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/services/InfusionsoftAuthenticationServiceImpl.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/services/InfusionsoftAuthenticationServiceImpl.java
@@ -72,10 +72,11 @@ public class InfusionsoftAuthenticationServiceImpl implements InfusionsoftAuthen
         if (loginResult != null) {
             incrementFailedLoginCount = loginResult.getLoginStatus() != LoginAttemptStatus.Success;
         } else {
+            UserPassword currentUserPassword = passwordService.getLatestPassword(user);
             if (userPassword == null) {
                 loginResult = LoginResult.BadPassword(user);
                 incrementFailedLoginCount = true;
-            } else if (!userPassword.isActive()) {
+            } else if (userPassword != currentUserPassword) {
                 loginResult = LoginResult.OldPassword(user);
                 incrementFailedLoginCount = false;  // Bad logins that used an old password don't increment the failure count
             } else {

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/services/PasswordService.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/services/PasswordService.java
@@ -5,11 +5,9 @@ import org.apereo.cas.infusionsoft.domain.UserPassword;
 import org.apereo.cas.infusionsoft.exceptions.InfusionsoftValidationException;
 
 public interface PasswordService {
-    boolean isPasswordCorrect(User user, String password);
-
     boolean isPasswordExpired(UserPassword password);
 
-    UserPassword getActivePasswordForUser(User user);
+    UserPassword getLatestPassword(User user);
 
     UserPassword getMatchingPasswordForUser(User user, String password);
 

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/webflow/InfusionsoftPasswordExpirationEnforcementAction.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/webflow/InfusionsoftPasswordExpirationEnforcementAction.java
@@ -90,7 +90,7 @@ public class InfusionsoftPasswordExpirationEnforcementAction extends AbstractAct
                         final Long userId = Long.parseLong(authenticationResult.getAuthentication().getPrincipal().getId());
 
                         User user = userService.loadUser(userId);
-                        UserPassword userPassword =  passwordService.getActivePasswordForUser(user);
+                        UserPassword userPassword =  passwordService.getLatestPassword(user);
                         Boolean passwordExpired = passwordService.isPasswordExpired(userPassword);
 
                         if (passwordExpired && infusionsoftRegisteredServiceAccessStrategy.isForcePasswordExpiration()) {

--- a/cas/src/test/java/org/apereo/cas/infusionsoft/services/InfusionsoftAuthenticationServiceTest.java
+++ b/cas/src/test/java/org/apereo/cas/infusionsoft/services/InfusionsoftAuthenticationServiceTest.java
@@ -32,9 +32,12 @@ public class InfusionsoftAuthenticationServiceTest {
     private InfusionsoftAuthenticationServiceImpl infusionsoftAuthenticationService;
     private User user;
     private UserPassword password;
+    private UserPassword newPassword;
     private static final String testUsername = "test.user@infusionsoft.com";
     private static final String testPassword = "passwordEncoded";
     private static final String testPasswordMD5 = "passwordEncodedMD5";
+    private static final String testNewPassword = "newPasswordEncoded";
+    private static final String testNewPasswordMD5 = "newPasswordEncodedMD5";
     private UserAccountTransformer userAccountTransformer;
 
     @Mock
@@ -100,6 +103,11 @@ public class InfusionsoftAuthenticationServiceTest {
         password.setPasswordEncoded(testPassword);
         password.setPasswordEncodedMD5(testPasswordMD5);
 
+        newPassword = new UserPassword();
+        newPassword.setUser(user);
+        newPassword.setPasswordEncoded(testNewPassword);
+        newPassword.setPasswordEncodedMD5(testNewPasswordMD5);
+
         when(passwordService.getMatchingPasswordForUser(any(User.class), anyString())).thenReturn(null);
         when(passwordService.getMatchingMD5PasswordForUser(any(User.class), anyString())).thenReturn(null);
 
@@ -111,11 +119,13 @@ public class InfusionsoftAuthenticationServiceTest {
 
         // TODO: use UTC date here
         password.setDateCreated(new Date());
-        password.setActive(true);
 
         setupFailedLogins(0);
         when(passwordService.getMatchingPasswordForUser(user, testPassword)).thenReturn(password);
         when(passwordService.getMatchingMD5PasswordForUser(user, testPasswordMD5)).thenReturn(password);
+        when(passwordService.getMatchingPasswordForUser(user, testNewPassword)).thenReturn(newPassword);
+        when(passwordService.getMatchingMD5PasswordForUser(user, testNewPasswordMD5)).thenReturn(newPassword);
+        when(passwordService.getLatestPassword(user)).thenReturn(password);
         when(passwordService.isPasswordExpired(password)).thenReturn(false);
     }
 
@@ -258,7 +268,7 @@ public class InfusionsoftAuthenticationServiceTest {
 
     @Test
     public void testAttemptLoginOldPassword() {
-        password.setActive(false);
+        when(passwordService.getLatestPassword(user)).thenReturn(newPassword);
         LoginResult loginResult = infusionsoftAuthenticationService.attemptLogin(testUsername, testPassword);
         Assert.assertEquals(loginResult.getLoginStatus(), LoginAttemptStatus.OldPassword);
         Assert.assertEquals(loginResult.getFailedAttempts(), 0);
@@ -368,7 +378,7 @@ public class InfusionsoftAuthenticationServiceTest {
 
     @Test
     public void testAttemptLoginWithMD5OldPassword() {
-        password.setActive(false);
+        when(passwordService.getLatestPassword(user)).thenReturn(newPassword);
         LoginResult loginResult = infusionsoftAuthenticationService.attemptLoginWithMD5Password(testUsername, testPasswordMD5);
         Assert.assertEquals(loginResult.getLoginStatus(), LoginAttemptStatus.OldPassword);
         Assert.assertEquals(loginResult.getFailedAttempts(), 0);


### PR DESCRIPTION
- Remove `active` flag on `UserPassword`
- Change `UserPasswordDao` to have new queries to get latest password and remove queries that user `active`
- Remove unused `isPasswordCorrect` method
- Update tests
- Update logic in `InfusionsoftAuthenticationService` to compare to latest password instead of `isActive`