### PR TITLE
Change serviceEssentials regex to use `optimus`

### DIFF
--- a/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftRegisteredServicesConfiguration.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftRegisteredServicesConfiguration.java
@@ -105,7 +105,7 @@ public class InfusionsoftRegisteredServicesConfiguration {
 
     @Bean
     RegisteredService serviceEssentials() {
-        RegexRegisteredService service = buildService(9, "Essentials", "(mobile|https?)://((diamondback\\.infusion(soft|test))|(is-propel-web-[^\\./:]+\\.firebaseapp))\\.com(:[0-9]+)?((/.*)|$)", 9);
+        RegexRegisteredService service = buildService(9, "Essentials", "(mobile|https?)://((diamondback\\.infusion(soft|test))|(is-optimus-web-[^\\./:]+\\.firebaseapp))\\.com(:[0-9]+)?((/.*)|$)", 9);
         service.setTheme("cas-theme-infusionsoft-design-2017");
 
         final Map<String, RegisteredServiceProperty> serviceProperties = service.getProperties();


### PR DESCRIPTION
Updated regex for url used in serviceEssentials to pick up
is-optimius-web (new) instead of is-propel-web (old).