### PR TITLE
AUTH-96: Add user info endpoint to CAS/AC 

### DIFF
--- a/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftMvcConfiguration.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftMvcConfiguration.java
@@ -9,10 +9,12 @@ import org.apereo.cas.infusionsoft.dao.SecurityQuestionResponseDAO;
 import org.apereo.cas.infusionsoft.services.*;
 import org.apereo.cas.infusionsoft.support.UserAccountTransformer;
 import org.apereo.cas.infusionsoft.web.controllers.AuthenticateController;
+import org.apereo.cas.infusionsoft.web.controllers.JwtController;
 import org.apereo.cas.infusionsoft.web.controllers.PasswordCheckController;
 import org.apereo.cas.infusionsoft.web.controllers.RegistrationController;
 import org.apereo.cas.services.ServicesManager;
 import org.apereo.cas.ticket.registry.TicketRegistry;
+import org.apereo.cas.token.cipher.TokenTicketCipherExecutor;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,9 +26,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration("infusionsoftMvcConfiguration")
 @EnableConfigurationProperties({CasConfigurationProperties.class, InfusionsoftConfigurationProperties.class})
 public class InfusionsoftMvcConfiguration {
-
-    @Autowired
-    private UserAccountTransformer userAccountTransformer;
 
     @Autowired
     private AuditService auditService;
@@ -75,7 +74,13 @@ public class InfusionsoftMvcConfiguration {
     private TicketRegistry ticketRegistry;
 
     @Autowired
-    UserService userService;
+    private TokenTicketCipherExecutor tokenTicketCipherExecutor;
+
+    @Autowired
+    private UserAccountTransformer userAccountTransformer;
+
+    @Autowired
+    private UserService userService;
 
     @Bean
     public AuthenticateController authenticateController() {
@@ -85,6 +90,11 @@ public class InfusionsoftMvcConfiguration {
     @Bean
     public AutoLoginService autoLoginService() {
         return new AutoLoginService(centralAuthenticationService, ticketGrantingTicketCookieGenerator, ticketRegistry, authenticationSystemSupport);
+    }
+
+    @Bean
+    public JwtController jwtController() {
+        return new JwtController(tokenTicketCipherExecutor, messageSource);
     }
 
     @Bean

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/web/controllers/JwtController.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/web/controllers/JwtController.java
@@ -1,0 +1,74 @@
+package org.apereo.cas.infusionsoft.web.controllers;
+
+import com.nimbusds.jose.proc.BadJWEException;
+import org.apereo.cas.api.APIErrorDTO;
+import org.apereo.cas.token.cipher.TokenTicketCipherExecutor;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.credentials.extractor.HeaderExtractor;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.exception.HttpAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Locale;
+
+/**
+ * Really simple controller to allow authentication.
+ */
+@RestController
+@RequestMapping(value = "/jwt")
+public class JwtController {
+    private static final Logger log = LoggerFactory.getLogger(JwtController.class);
+
+    private MessageSource messageSource;
+
+    private TokenTicketCipherExecutor tokenTicketCipherExecutor;
+
+    public JwtController(TokenTicketCipherExecutor tokenTicketCipherExecutor, MessageSource messageSource) {
+        this.tokenTicketCipherExecutor = tokenTicketCipherExecutor;
+        this.messageSource = messageSource;
+    }
+
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity decrypt(HttpServletRequest request, HttpServletResponse response, Locale locale) throws CredentialsException, HttpAction {
+        J2EContext context = new J2EContext(request, response);
+
+        try {
+            HeaderExtractor headerExtractor = new HeaderExtractor("Authorization", "Bearer ", "(CAS) JWT Validator");
+            TokenCredentials tokenCredentials = headerExtractor.extract(context);
+
+            if (tokenCredentials != null) {
+                String decrypted = tokenTicketCipherExecutor.decode(tokenCredentials.getToken());
+
+                if(decrypted != null) {
+                    return new ResponseEntity<>(decrypted, HttpStatus.OK);
+                } else {
+                    throw new BadJWEException("Invalid JWE Token");
+                }
+            } else {
+                throw new BadJWEException("Invalid JWE Token");
+            }
+        } catch (CredentialsException | IllegalArgumentException | BadJWEException e) {
+            return logAndReturnError(e, "cas.exception.jwt.invalid", new Object[]{e.getMessage()}, locale, HttpStatus.UNAUTHORIZED);
+        }
+
+    }
+
+    private ResponseEntity<APIErrorDTO> logAndReturnError(Exception e, String code, Object[] args, Locale locale, HttpStatus httpStatus) {
+        String errorMessage = messageSource.getMessage(code, args, locale);
+        log.error(errorMessage, e);
+        return new ResponseEntity<>(new APIErrorDTO(code, errorMessage), httpStatus);
+    }
+
+}

--- a/cas/src/main/resources/custom_messages.properties
+++ b/cas/src/main/resources/custom_messages.properties
@@ -96,6 +96,7 @@ password.error.cantmatch=Password must not match any of your last 4 passwords.
 # By convention, error codes returned by the API should start with "cas." so they will be unique if used by the client
 cas.exception.general=Unexpected error: {0}
 cas.exception.invalid.call=Could not call controller function due to error: {0}
+cas.exception.jwt.invalid=Invalid JWT: {0}
 cas.exception.authenticateUser.failure=Unable to authenticate user {0}
 
 # email text

--- a/cas/src/main/resources/custom_messages.properties
+++ b/cas/src/main/resources/custom_messages.properties
@@ -96,7 +96,7 @@ password.error.cantmatch=Password must not match any of your last 4 passwords.
 # By convention, error codes returned by the API should start with "cas." so they will be unique if used by the client
 cas.exception.general=Unexpected error: {0}
 cas.exception.invalid.call=Could not call controller function due to error: {0}
-cas.exception.jwt.invalid=Invalid JWT: {0}
+cas.exception.jwt.invalid=Invalid JWT
 cas.exception.authenticateUser.failure=Unable to authenticate user {0}
 
 # email text


### PR DESCRIPTION
Add user info endpoint to CAS/AC that allows someone to convert a JWT into user information.

Verification:
- Login into CAS using https://devcas.infusiontest.com:7443/login?service=http://localhost:8080/jwt
- This will redirect to nowhere but it will have a JWT in the `ticket` query param
- Make a call using postman using the JWT as a `Authorization: Bearer {token}` header
```
GET /jwt HTTP/1.1
Host: devcas.infusiontest.com:7443
Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.WlhsS05tRllRV2xQYVVwRlVsVlphVXhEU21oaVIyTnBUMmxLYTJGWVNXbE1RMHBzWW0xTmFVOXBTa0pOVkVrMFVUQktSRXhWYUZSTmFsVXlTVzR3TGk0d1J6SnFOWGxQWlhKNmNEUlpjM04xWW01aVNGaFJMa1JTVkc5dFJVdGtiV2N4YUhadlJrdHpaR0pZWTBneloyOWZURU4xZFY5R2FXOTZNVVJ0Vmt4SmQzQmhTMDlOWDBzNFkzQXdOVmRHVjFjMWIwcHJXRkpvTmxkU1NrbzJOVkZzUVRWNFdHVkRORlp3ZWxsR09IQm1jMk53Y1RKQmFIbE1RV2h5Y1VWSExXMDVla0UzYmpsWk1rdzVVMVpQYVhkdlozQkdjQzFUVWxCSVVVUjNTMkYwV1ZwRWMwTjVOWGt5WjBSaWJ6azJlVTlOVFdORGVIVk9PRGRuZUhkRVNYRlpYek5oYmxoeFUyUldNemwyT1VkVFpGQkZTRmxLTUMxMlFWOVplR3c1ZGt0Q1RXYzBjakIzT0djeVRGZDZORkJsZUdkTmNtaFZXWE13WnpoMlkyVjBlVkZHVlRORU5YQlNVSHBIWlhscVgzUnJTRzVvV25obk5UWTRNMDlmV0RadWFrWlJSbWd3U2xOV1dWaGZkVzR6UWtWTFpGbHlVelZ4TjFoVGFVSjZURzg0TTBSR1JsVXpOR3c0UWtSMmVGbzFVV2M0WkhKSExVSjBZM3ByV0hOM1JERnlTMUUyVkRWMGFHUk5OeTFzZVZZeFkwUlVSMkZwYlVGVlgxbGFjVzVqVVRac1VrTk5jbVJaV1VneFVFeERaVzFJVG5keVJYVTNaRE5xYTJSSE9XTmxRUzFvZEhKSVFUaFdjbGhTWldOeFVsOUJaMUJNWlZJNExWVkthbVY1VEU5blRHWlVRVlUwVVZveE4wUXphVkF3V1RaRmRrTllhRWhOWjJwVU4wNWZSMngzVTJGSlRWaERXbkF4Umt4b1Vtc3pjbHA0VlVSc01WWjVORmhIWld4ZlprcHpTVUU1TW14cGRrVkhRM2w1Y1MxR1lrbFhTbFpTVWpScVZrdFhaM1JrTVhGdlRXWTFWa0ZHU2xGTVVqY3hjMUJ3YUROUVZFOTZhVmxDVkdNemMxZGlUbEEwWmpKcFpYcDZlV2xzTTJkVFdYaE1RWG96VDBwUFluVjBhVW8wUVVWaGFFRkxaSFZTY210bk1uaEpSR2hZY1VsbVJISlBhMEV0UmtzMlVVMDFUVmcyTTJVNE1XMVNWVmRVU1dVNVdHdEhUaTF1WTBVdFZtdFVVVVp6VUdVeFFpMTRhbUZsY2toblltWnNWbkpVWjE4eGNVY3ROVWR6VWxSWWFHZHZTWGhtVkdkd2NGSlllSE5ZVlRGdU1URmZYM1Z6UkdVek5rRkJkRVUzZGxRemRqTnpVVUpqV1hWRlJIRnlSVmRSTmtWYU1YcEhZVTl6UjBSUVJqSnFVSGszVms5MGRrOVFlRGRFU0VoRE0yOVpVRkZWTnpoNGNVeEtlbFEwV2pNNVVtSldiMmMwYlZWUVZEaFVSa0ZtWkZSV1NIVkpTM1p5WTFscWRWWjZaelo2TVRWdlNrSnhRMk5SYjBkSldFcFJSbVZhUjJ0WE1XWmlVMVZRZVdkVWFscEphSHBTUlZoMlpHVm5MbnAxWVU5cVFXazRlbDlKTTBwbk9UZzVhR3RHVTNjPQ.u_2Wdrw0Loytygz9gs2whUq-YJvZiOxKDRgwxYmeD2w7zhe8IAW5fSseWc8QvT1nFWPQW8ZltjpHgx_EHUJOrw
Cache-Control: no-cache
Postman-Token: 723788b5-116f-cf9b-4672-5b7ac06d6746
```

You should get a valid json response that looks like this:
```
{
    "sub": "21",
    "lastName": "Booth1",
    "isFromNewLogin": "true",
    "authenticationDate": "2017-08-01T21:46:49.555-07:00[America/Phoenix]",
    "displayName": "Bradley1 Booth1",
    "successfulAuthenticationHandlers": "Infusionsoft Authentication Handler",
    "iss": "https://devcas.infusiontest.com:7443",
    "authorities": [
        "ROLE_CAS_MARKETING_ADMIN",
        "ROLE_CAS_STEALTH_CRM",
        "ROLE_CAS_SUPPORT_TIER_2",
        "ROLE_CAS_LISTING_ADMIN_MARKETPLACE",
        "ROLE_CAS_ADMIN",
        "ROLE_CAS_USER",
        "ROLE_CAS_LISTING_PUBLISHER_MARKETPLACE",
        "ROLE_CAS_SUPPORT_TIER_1"
    ],
    "aud": "http://localhost:8080/jwt",
    "firstName": "Bradley1",
    "authenticationMethod": "Infusionsoft Authentication Handler",
    "longTermAuthenticationRequestTokenUsed": "false",
    "id": "21",
    "accounts": "[{\"appType\":\"CRM\",\"appName\":\"a46\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"a46n\",\"appUrl\":\"https://a46.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"a54\",\"appUsername\":\"bbooth\",\"appAlias\":\"a54\",\"appUrl\":\"https://a54.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"a56\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"a56\",\"appUrl\":\"https://a56.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"devbox\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"devbox\",\"appUrl\":\"https://devbox.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"g36\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"g36\",\"appUrl\":\"https://g36.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"g46\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"g46\",\"appUrl\":\"https://g46.infusiontest.com:8443\"},{\"appType\":\"CRM\",\"appName\":\"mashery1\",\"appUsername\":\"bradb@infusionsoft.com\",\"appAlias\":\"mashery1test\",\"appUrl\":\"https://mashery1.infusiontest.com:8443\"}]",
    "exp": 1501908475,
    "iat": 1501649275,
    "jti": "ST-1-HZP4VHvbVGxHdaRn7fmt-devcas.infusiontest.com",
    "email": "bradb@infusionsoft.com"
}
```

Validate bad data:
- No Authorization Header should return 401.
- Authorization Header does not start with `Bearer` should return 401.
- Authorization Header present but missing but token has invalid format should return 401 (remove everything in the token before the `.`)
- Valid format for JWT but token can't be decrypted should return 401 (add a `-bad` to the end of the token so it fails decryption).