### PR TITLE
AUTH-101: Add endpoint to clear hazelcast caches

### DIFF
--- a/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftMvcConfiguration.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/config/InfusionsoftMvcConfiguration.java
@@ -8,11 +8,9 @@ import org.apereo.cas.infusionsoft.dao.SecurityQuestionDAO;
 import org.apereo.cas.infusionsoft.dao.SecurityQuestionResponseDAO;
 import org.apereo.cas.infusionsoft.services.*;
 import org.apereo.cas.infusionsoft.support.UserAccountTransformer;
-import org.apereo.cas.infusionsoft.web.controllers.AuthenticateController;
-import org.apereo.cas.infusionsoft.web.controllers.JwtController;
-import org.apereo.cas.infusionsoft.web.controllers.PasswordCheckController;
-import org.apereo.cas.infusionsoft.web.controllers.RegistrationController;
+import org.apereo.cas.infusionsoft.web.controllers.*;
 import org.apereo.cas.services.ServicesManager;
+import org.apereo.cas.ticket.registry.HazelcastTicketRegistry;
 import org.apereo.cas.ticket.registry.TicketRegistry;
 import org.apereo.cas.token.cipher.TokenTicketCipherExecutor;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
@@ -61,6 +59,9 @@ public class InfusionsoftMvcConfiguration {
     private PasswordService passwordService;
 
     @Autowired
+    private HazelcastTicketRegistry hazelcastTicketRegistry;
+
+    @Autowired
     private SecurityQuestionDAO securityQuestionDAO;
 
     @Autowired
@@ -90,6 +91,11 @@ public class InfusionsoftMvcConfiguration {
     @Bean
     public AutoLoginService autoLoginService() {
         return new AutoLoginService(centralAuthenticationService, ticketGrantingTicketCookieGenerator, ticketRegistry, authenticationSystemSupport);
+    }
+
+    @Bean
+    public HazelcastController hazelcastController() {
+        return new HazelcastController(hazelcastTicketRegistry);
     }
 
     @Bean

--- a/cas/src/main/java/org/apereo/cas/infusionsoft/web/controllers/HazelcastController.java
+++ b/cas/src/main/java/org/apereo/cas/infusionsoft/web/controllers/HazelcastController.java
@@ -1,0 +1,36 @@
+package org.apereo.cas.infusionsoft.web.controllers;
+
+import org.apereo.cas.ticket.registry.HazelcastTicketRegistry;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.exception.HttpAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Really simple controller to allow authentication.
+ */
+@RestController
+@RequestMapping(value = "/status/cache")
+public class HazelcastController {
+    private static final Logger log = LoggerFactory.getLogger(HazelcastController.class);
+
+    private HazelcastTicketRegistry hazelcastTicketRegistry;
+
+    public HazelcastController(HazelcastTicketRegistry hazelcastTicketRegistry) {
+        this.hazelcastTicketRegistry = hazelcastTicketRegistry;
+    }
+
+    @RequestMapping(value = "/clear", method = RequestMethod.GET, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity clear() throws CredentialsException, HttpAction {
+        log.warn("Clearing all ticket registries");
+        return new ResponseEntity<>(hazelcastTicketRegistry.deleteAll(), HttpStatus.OK);
+    }
+
+}


### PR DESCRIPTION
Add endpoint to CAS to allow us to clear hazelcast caches locked down by our existing IP whitelisting for `/status/**`

The response will return how many tickets were deleted from the cache.  This should be only be accessible by `127.0.0.1` in dev and behind our VPN in proofing and prod.  Might be hard to test this portion until it is merged.

```http
GET /status/cache/clear HTTP/1.1
Host: devcas.infusiontest.com:7443
Cache-Control: no-cache
Postman-Token: 0726836b-4447-5bed-23a6-c43e79abfe1c
```