### PR TITLE
Remove cas-holiday.css

### DIFF
--- a/cas/src/main/resources/templates/casLoginView.html
+++ b/cas/src/main/resources/templates/casLoginView.html
@@ -16,7 +16,6 @@
 
 <head>
     <title th:text="#{cas.login.pagetitle}"></title>
-    <link type="text/css" rel="stylesheet" href="https://infusionmedia.s3.amazonaws.com/app/login-screen/cas-holiday.css">
 </head>
 
 <body>


### PR DESCRIPTION
This is a zero byte resource that is still being loaded. Banners are now sourced from files.infusionsoft.com.