### PR TITLE
AUTH-102: Remove WalkMe references

### DIFF
--- a/cas/src/main/resources/templates/fragments/infusionsoft-js.html
+++ b/cas/src/main/resources/templates/fragments/infusionsoft-js.html
@@ -24,14 +24,3 @@
     ga('send', 'pageview');
 </script>
 
-<script type="text/javascript">
-    (function() {
-        var walkme = document.createElement('script');
-        walkme.type = 'text/javascript';
-        walkme.async = true;
-        walkme.src = 'https://d3b3ehuo35wzeh.cloudfront.net/users/6543/walkme_6543_https.js';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(walkme, s);
-    })();
-</script>
-


### PR DESCRIPTION
Remove Walkme javascript from CAS.  You can verify this by looking for the walkme script on the cas login page.