### PR TITLE
AUTH-108: Remove Google Analytics

### DIFF
--- a/cas/src/main/resources/templates/fragments/infusionsoft-js.html
+++ b/cas/src/main/resources/templates/fragments/infusionsoft-js.html
@@ -7,20 +7,4 @@
 <!--<script src="//cdnjs.cloudflare.com/ajax/libs/headjs/1.0.3/head.min.js"></script>-->
 <script type="text/javascript" th:src="@{${#themes.code('infusionsoft.javascript.file')}}"></script>
 
-<script type="text/javascript">
-    (function(i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
-        i[r] = i[r] || function() {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date();
-        a = s.createElement(o),
-            m = s.getElementsByTagName(o)[0];
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-
-    ga('create', 'UA-53595407-1', 'auto');
-    ga('send', 'pageview');
-</script>
 


### PR DESCRIPTION
Remove the GA javascript from CAS

```js
<script type="text/javascript">
    (function(i, s, o, g, r, a, m) {
        i['GoogleAnalyticsObject'] = r;
        i[r] = i[r] || function() {
                (i[r].q = i[r].q || []).push(arguments)
            }, i[r].l = 1 * new Date();
        a = s.createElement(o),
            m = s.getElementsByTagName(o)[0];
        a.async = 1;
        a.src = g;
        m.parentNode.insertBefore(a, m)
    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');

    ga('create', 'UA-53595407-1', 'auto');
    ga('send', 'pageview');
</script>
```